### PR TITLE
Add missing datetime dependency

### DIFF
--- a/dash-plotly-132-histogram-data-simple.py
+++ b/dash-plotly-132-histogram-data-simple.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from textwrap import dedent as d
 import dash
 from dash.dependencies import Input, Output


### PR DESCRIPTION
The example uses `datetime` but does not import it. This PR fixes the missing dependency.