### PR TITLE
need to specify height 100% to see all rows

### DIFF
--- a/dash-textarea-height.py
+++ b/dash-textarea-height.py
@@ -11,7 +11,7 @@ app.layout = html.Div(
                 id='input_query',
                 placeholder='Enter/Review Query...',
                 rows=50,
-                style={'width': '100%'}
+                style={'width': '100%', 'height':'100%'}
             ),
         ]),
     ])


### PR DESCRIPTION
When testing the 'rows' field from the TextArea, I noticed I need to add a 'height': '100%' otherwise I see only 3 rows per default 