### PR TITLE
Fix TextArea height to update based on rows

### DIFF
--- a/dash-textarea-height.py
+++ b/dash-textarea-height.py
@@ -11,7 +11,7 @@ app.layout = html.Div(
                 id='input_query',
                 placeholder='Enter/Review Query...',
                 rows=50,
-                style={'width': '100%'}
+                style={'width': '100%', 'height': 'auto'}
             ),
         ]),
     ])


### PR DESCRIPTION
I tried the example code and it did not work. Perhaps the CSS is adding `height` which interferes with `rows`. Setting it to `auto` fixes the example.