### PR TITLE
Change slow .iloc to .iat in dash-html-table-hyperlinks

### DIFF
--- a/dash-html-table-hyperlinks.py
+++ b/dash-html-table-hyperlinks.py
@@ -9,10 +9,12 @@ df = pd.DataFrame({
 
 def Table(dataframe):
     rows = []
+    cols = dataframe.columns
     for i in range(len(dataframe)):
         row = []
-        for col in dataframe.columns:
-            value = dataframe.iloc[i][col]
+        for j in range(len(cols)):
+            col = cols[j]
+            value = dataframe.iat[i,j]
             # update this depending on which
             # columns you want to show links for
             # and what you want those links to be


### PR DESCRIPTION
Tested on a DF with 1,000 rows this method gives the same result and is 10x faster. Minor change had to be made to ensure the same behaviour in terms of reading index position not index (so the DF index can still be arbitrary)